### PR TITLE
notify-send doesn't exist on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ xinput-toggle -r yubikey -e -t 5
 
 - xinput
 - bash 4+
-- notify-send (optional, for `-n`)
+- notify-send (optional, for `-n`, aka libnotify)


### PR DESCRIPTION
I found after looking at the Arch package that libnotify fills this role.